### PR TITLE
Check that methodtracer is not nil before adding it as a middleware

### DIFF
--- a/query.go
+++ b/query.go
@@ -79,7 +79,7 @@ func makeQueryerContextMiddlewares(r methodRecorder, t methodTracer, cfg queryCo
 
 	middlewares = append(middlewares, queryStats(r, cfg.metricMethod))
 
-	if t != nil {
+	if t == nil {
 		return middlewares
 	}
 

--- a/query.go
+++ b/query.go
@@ -77,10 +77,13 @@ func queryWrapRows(t methodTracer, traceLastInsertID bool, traceRowsAffected boo
 func makeQueryerContextMiddlewares(r methodRecorder, t methodTracer, cfg queryConfig) []queryContextFuncMiddleware {
 	middlewares := make([]queryContextFuncMiddleware, 0, 3)
 
-	middlewares = append(middlewares,
-		queryStats(r, cfg.metricMethod),
-		queryTrace(t, cfg.traceQuery, cfg.traceMethod),
-	)
+	middlewares = append(middlewares, queryStats(r, cfg.metricMethod))
+
+	if t != nil {
+		return middlewares
+	}
+
+	middlewares = append(middlewares, queryTrace(t, cfg.traceQuery, cfg.traceMethod))
 
 	if cfg.traceRowsNext || cfg.traceRowsClose {
 		middlewares = append(middlewares, queryWrapRows(t, cfg.traceRowsNext, cfg.traceRowsClose))


### PR DESCRIPTION
Fixes bug that causes runtime panics if configuration is setup without `AllowRoot`.